### PR TITLE
Improve UI with sidebar and shadcn components

### DIFF
--- a/app/components/sidebar.tsx
+++ b/app/components/sidebar.tsx
@@ -1,0 +1,50 @@
+import { Link, useLocation } from "react-router";
+import {
+  Home,
+  Catalog,
+  ShoppingCart,
+  User,
+  UserAvatar,
+  Login,
+  UserFollow,
+} from "@carbon/icons-react";
+
+import { cn } from "../lib/utils";
+
+const navItems = [
+  { to: "/", label: "Home", icon: Home },
+  { to: "/records", label: "Records", icon: Catalog },
+  { to: "/cart", label: "Cart", icon: ShoppingCart },
+  { to: "/buyer", label: "Buyer", icon: UserAvatar },
+  { to: "/seller", label: "Seller", icon: User },
+  { to: "/signin", label: "Sign In", icon: Login },
+  { to: "/signup", label: "Sign Up", icon: UserFollow },
+];
+
+export function Sidebar() {
+  const location = useLocation();
+  return (
+    <aside className="hidden h-screen w-64 shrink-0 border-r bg-white/70 p-4 md:block">
+      <nav className="grid gap-1 text-sm font-medium">
+        {navItems.map((item) => {
+          const Icon = item.icon;
+          const active = location.pathname === item.to;
+          return (
+            <Link
+              key={item.to}
+              to={item.to}
+              className={cn(
+                "flex items-center gap-3 rounded-md px-3 py-2 hover:bg-gray-100",
+                active && "bg-gray-100 font-semibold"
+              )}
+            >
+              <Icon className="h-5 w-5" />
+              {item.label}
+            </Link>
+          );
+        })}
+      </nav>
+    </aside>
+  );
+}
+

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -5,8 +5,8 @@ import {
   Outlet,
   Scripts,
   ScrollRestoration,
-  Link,
 } from "react-router";
+import { Sidebar } from "./components/sidebar";
 import { ClerkProvider } from "@clerk/clerk-react";
 
 import type { Route } from "./+types/root";
@@ -34,24 +34,17 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <Meta />
         <Links />
       </head>
-      <body>
-        <header className="border-b bg-white/80 backdrop-blur">
-          <nav className="container flex h-14 items-center justify-between">
-            <Link to="/" className="text-lg font-bold tracking-tight">
-              Revolv
-            </Link>
-            <div className="flex items-center gap-6">
-              <Link to="/records" className="font-medium hover:text-blue-600">
-                Records
-              </Link>
-              <Link to="/cart" className="font-medium hover:text-blue-600">
-                Cart
-              </Link>
-            </div>
-          </nav>
-        </header>
-        <div className="min-h-screen">
-          {children}
+      <body className="min-h-screen bg-gray-50 font-sans antialiased">
+        <div className="flex min-h-screen">
+          <Sidebar />
+          <div className="flex-1 flex flex-col">
+            <header className="flex h-14 items-center border-b bg-white px-4">
+              <a href="/" className="text-lg font-bold tracking-tight">
+                Revolv
+              </a>
+            </header>
+            <div className="flex-1">{children}</div>
+          </div>
         </div>
         <ScrollRestoration />
         <Scripts />

--- a/app/routes/buyer.tsx
+++ b/app/routes/buyer.tsx
@@ -9,6 +9,7 @@ import {
 } from "../data/store";
 import { Button } from "../components/ui/button";
 import { Input } from "../components/ui/input";
+import { Card } from "../ui/card";
 
 export async function loader(_args: LoaderFunctionArgs) {
   const profile = await getProfile();
@@ -51,28 +52,30 @@ export default function BuyerProfilePage() {
     <div className="container max-w-4xl space-y-8 py-8">
       <h1 className="text-3xl font-bold tracking-tight">Buyer Profile</h1>
 
-      <Form method="post" className="space-y-4 rounded-md border bg-white p-4 shadow">
-        <input type="hidden" name="intent" value="update-profile" />
-        <div className="space-y-2">
-          <label className="block text-sm font-medium" htmlFor="name">
-            Name
-          </label>
-          <Input id="name" name="name" defaultValue={profile.name} />
-        </div>
-        <div className="space-y-2">
-          <label className="block text-sm font-medium" htmlFor="bio">
-            Bio
-          </label>
-          <Input id="bio" name="bio" defaultValue={profile.bio} />
-        </div>
-        <Button type="submit">Save Profile</Button>
-      </Form>
+      <Card>
+        <Form method="post" className="space-y-4">
+          <input type="hidden" name="intent" value="update-profile" />
+          <div className="space-y-2">
+            <label className="block text-sm font-medium" htmlFor="name">
+              Name
+            </label>
+            <Input id="name" name="name" defaultValue={profile.name} />
+          </div>
+          <div className="space-y-2">
+            <label className="block text-sm font-medium" htmlFor="bio">
+              Bio
+            </label>
+            <Input id="bio" name="bio" defaultValue={profile.bio} />
+          </div>
+          <Button type="submit">Save Profile</Button>
+        </Form>
+      </Card>
 
       <section className="space-y-4">
         <h2 className="text-2xl font-semibold">Collection</h2>
         <ul className="space-y-4">
           {profile.collection.map((v) => (
-            <li key={v.id} className="rounded-md border bg-white p-4 shadow space-y-2">
+            <Card key={v.id} className="space-y-2">
               <p className="font-medium">
                 {v.title} - {v.artist} ({v.year})
               </p>
@@ -86,13 +89,14 @@ export default function BuyerProfilePage() {
                 />
                 <Button type="submit">I'm Interested</Button>
               </Form>
-            </li>
+            </Card>
           ))}
         </ul>
 
-        <Form method="post" className="mt-8 space-y-4 rounded-md border bg-white p-4 shadow">
-          <input type="hidden" name="intent" value="add-vinyl" />
-          <h3 className="text-lg font-medium">Add Vinyl</h3>
+        <Card className="mt-8 p-4">
+          <Form method="post" className="space-y-4">
+            <input type="hidden" name="intent" value="add-vinyl" />
+            <h3 className="text-lg font-medium">Add Vinyl</h3>
           <div className="space-y-2">
             <label className="block text-sm font-medium" htmlFor="title">
               Title
@@ -111,8 +115,9 @@ export default function BuyerProfilePage() {
             </label>
             <Input id="year" name="year" type="number" required />
           </div>
-          <Button type="submit">Add</Button>
-        </Form>
+            <Button type="submit">Add</Button>
+          </Form>
+        </Card>
       </section>
     </div>
   );

--- a/app/routes/cart.tsx
+++ b/app/routes/cart.tsx
@@ -3,6 +3,7 @@ import type { Route } from "./+types/cart";
 import { getCart, removeFromCart, clearCart, addToCart } from "~/utils/cart";
 import { records } from "~/data/records";
 import { Button } from "~/components/ui/button";
+import { Card } from "~/ui/card";
 
 export function loader() {
   return getCart();
@@ -39,9 +40,9 @@ export default function Cart() {
         <>
           <ul className="space-y-2">
             {items.map((item) => (
-              <li
+              <Card
                 key={item.id}
-                className="flex items-center justify-between rounded-md border bg-white p-4 shadow"
+                className="flex items-center justify-between"
               >
                 <div>
                   <p className="font-semibold">{item.title}</p>
@@ -54,7 +55,7 @@ export default function Cart() {
                     Remove
                   </Button>
                 </Form>
-              </li>
+              </Card>
             ))}
           </ul>
           <div className="text-right font-semibold">Total: ${total.toFixed(2)}</div>

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -7,6 +7,7 @@ import {
   SignOutButton,
 } from "@clerk/clerk-react";
 import { Button } from "../components/ui/button";
+import { Card } from "../ui/card";
 import type { Record } from "../data/records";
 import { records as sampleRecords } from "../data/records";
 
@@ -31,10 +32,7 @@ export default function Home() {
       </h1>
       <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
         {records.map((record) => (
-          <div
-            key={record.id}
-            className="space-y-2 text-center rounded-lg border bg-white p-4 shadow"
-          >
+          <Card key={record.id} className="space-y-2 text-center">
             <img
               src={record.cover}
               alt={`${record.title} cover`}
@@ -42,7 +40,7 @@ export default function Home() {
             />
             <p className="font-medium">{record.title}</p>
             <p className="text-sm text-gray-600">{record.artist}</p>
-          </div>
+          </Card>
         ))}
       </div>
       <div className="text-center space-x-4">

--- a/app/routes/records.tsx
+++ b/app/routes/records.tsx
@@ -2,6 +2,7 @@ import { Form, useLoaderData } from "react-router";
 import type { Route } from "./+types/records";
 import { records } from "~/data/records";
 import { Button } from "~/components/ui/button";
+import { Card } from "~/ui/card";
 
 export function loader() {
   return records;
@@ -14,7 +15,7 @@ export default function Records() {
       <h1 className="text-3xl font-bold tracking-tight">Records</h1>
       <ul className="grid grid-cols-1 gap-6 sm:grid-cols-2 md:grid-cols-3">
         {data.map((record) => (
-          <li key={record.id} className="space-y-2 rounded-lg border bg-white p-4 shadow">
+          <Card key={record.id} className="space-y-2">
             <img src={record.cover} alt={record.title} className="w-full rounded-md" />
             <h2 className="font-semibold">{record.title}</h2>
             <p className="text-sm text-gray-500">{record.artist}</p>
@@ -26,7 +27,7 @@ export default function Records() {
                 Add to Cart
               </Button>
             </Form>
-          </li>
+          </Card>
         ))}
       </ul>
     </main>

--- a/app/routes/seller.tsx
+++ b/app/routes/seller.tsx
@@ -52,11 +52,11 @@ export default function Seller() {
         ) : (
           <ul className="space-y-2">
             {records.map((record) => (
-              <li key={record.id} className="rounded-md border bg-white p-4 shadow">
+              <Card key={record.id}>
                 <p className="font-medium">{record.title}</p>
                 <p className="text-sm text-gray-600">${record.price.toFixed(2)}</p>
                 <p className="text-sm text-gray-500">{record.description}</p>
-              </li>
+              </Card>
             ))}
           </ul>
         )}

--- a/app/routes/signin.tsx
+++ b/app/routes/signin.tsx
@@ -2,7 +2,7 @@ import { SignIn } from "@clerk/clerk-react";
 
 export default function SignInRoute() {
   return (
-    <main className="flex min-h-screen items-center justify-center bg-gray-100">
+    <main className="flex min-h-[calc(100vh_-_56px)] items-center justify-center p-6">
       <SignIn />
     </main>
   );

--- a/app/routes/signup.tsx
+++ b/app/routes/signup.tsx
@@ -2,7 +2,7 @@ import { SignUp } from "@clerk/clerk-react";
 
 export default function SignUpRoute() {
   return (
-    <main className="flex min-h-screen items-center justify-center bg-gray-100">
+    <main className="flex min-h-[calc(100vh_-_56px)] items-center justify-center p-6">
       <SignUp />
     </main>
   );

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "isbot": "^5.1.27",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router": "^7.5.3"
+    "react-router": "^7.5.3",
+    "@carbon/icons-react": "^11.50.0"
   },
   "devDependencies": {
     "@react-router/dev": "^7.5.3",


### PR DESCRIPTION
## Summary
- add carbon icons dependency
- implement a reusable sidebar with carbon icons
- integrate sidebar in the root layout
- modernize pages to use `Card` components
- tweak sign in/up pages styling

## Testing
- `npm run build` *(fails: react-router not found)*